### PR TITLE
remove extraneous(?) invisible characters

### DIFF
--- a/citizen_code_of_conduct.md
+++ b/citizen_code_of_conduct.md
@@ -1,123 +1,123 @@
 # Citizen Code of Conduct
 
-## 1.‭ ‬Purpose
+## 1. Purpose
 
-A‭ ‬primary‭ ‬goal‭ ‬of‭ ‬COMMUNITY‭_‬NAME‭ ‬is‭ ‬to‭ ‬be‭ ‬inclusive‭ ‬to‭
-‬the‭ ‬largest‭ ‬number‭ ‬of‭ ‬contributors,‭ ‬with‭ ‬the‭ ‬most‭ ‬varied‭
-‬and‭ ‬diverse‭ ‬backgrounds‭ ‬possible.‭ ‬As‭ ‬such,‭ ‬we‭ ‬are‭ ‬committed‭
-‬to‭ ‬providing‭ ‬a‭ ‬friendly,‭ ‬safe‭ ‬and‭ ‬welcoming‭ ‬environment‭ ‬for‭
-‬all,‭ ‬regardless‭ ‬of‭ ‬gender,‭ ‬sexual‭ ‬orientation,‭ ‬ability,‭
-‬ethnicity,‭ ‬socioeconomic‭ ‬status,‭ ‬and‭ ‬religion‭ (‬or‭ ‬lack‭
-‬thereof‭)‬.‭
+A primary goal of COMMUNITY_NAME is to be inclusive to
+the largest number of contributors, with the most varied
+and diverse backgrounds possible. As such, we are committed
+to providing a friendly, safe and welcoming environment for
+all, regardless of gender, sexual orientation, ability,
+ethnicity, socioeconomic status, and religion (or lack
+thereof).
 
-This‭ ‬code‭ ‬of‭ ‬conduct‭ ‬outlines‭ ‬our‭ ‬expectations‭ ‬for‭ ‬all‭
-‬those‭ ‬who‭ ‬participate‭ ‬in‭ ‬our‭ ‬community,‭ ‬as‭ ‬well‭ ‬as‭ ‬the‭
-‬consequences‭ ‬for‭ ‬unacceptable‭ ‬behavior.
+This code of conduct outlines our expectations for all
+those who participate in our community, as well as the
+consequences for unacceptable behavior.
 
-We‭ ‬invite‭ ‬all‭ ‬those‭ ‬who‭ ‬participate‭ ‬in‭ ‬COMMUNITY‭_‬NAME‭ ‬to‭
-‬help‭ ‬us‭ ‬create‭ ‬safe‭ ‬and‭ ‬positive‭ ‬experiences‭ ‬for‭ ‬everyone.
+We invite all those who participate in COMMUNITY_NAME to
+help us create safe and positive experiences for everyone.
 
-## 2.‎ ‏Open‭ [‬Source/Culture/Tech‭] ‬Citizenship
+## 2.‎ ‏Open [Source/Culture/Tech] Citizenship
 
-A‭ ‬supplemental‭ ‬goal‭ ‬of‭ ‬this‭ ‬Code‭ ‬of‭ ‬Conduct‭ ‬is‭ ‬to‭
-‬increase‭ ‬open‭ [‬source/culture‭/tech] ‬citizenship‭ ‬by‭ ‬encouraging‭
-‬participants‭ ‬to‭ ‬recognize‭ ‬and‭ ‬strengthen‭ ‬the‭ ‬relationships‭
-‬between‭ ‬our‭ ‬actions‭ ‬and‭ ‬their‭ ‬effects‭ ‬on‭ ‬our‭ ‬community.
+A supplemental goal of this Code of Conduct is to
+increase open [source/culture/tech] citizenship by encouraging
+participants to recognize and strengthen the relationships
+between our actions and their effects on our community.
 
 Communities mirror the societies in which they exist and positive action is essential to counteract the many forms of inequality and abuses of power that exist in society.
 
-If‭ ‬you‭ ‬see‭ ‬someone‭ ‬who‭ ‬is‭ ‬making‭ ‬an‭ ‬extra‭ ‬effort‭ ‬to‭
-‬ensure‭ ‬our‭ ‬community‭ ‬is‭ ‬welcoming,‭ ‬friendly,‭ ‬and‭ ‬encourages‭
-‬all‭ ‬participants‭ ‬to‭ ‬contribute‭ ‬to‭ ‬the‭ ‬fullest‭ ‬extent,‭ ‬we‭
-‬want‭ ‬to‭ ‬know.
+If you see someone who is making an extra effort to
+ensure our community is welcoming, friendly, and encourages
+all participants to contribute to the fullest extent, we
+want to know.
 
-## 3.‎ ‏Expected‭ ‬Behavior
+## 3.‎ ‏Expected Behavior
 
-  * Participate‭ ‬in‭ ‬an‭ ‬authentic‭ ‬and‭ ‬active‭ ‬way.‭ ‬In‭ ‬doing‭ ‬so,‭ ‬you‭ ‬contribute‭ ‬to‭ ‬the‭ ‬health‭ ‬and‭ ‬longevity‭ ‬of‭ ‬this‭ ‬community.
-  * Exercise‭ ‬consideration‭ ‬and‭ ‬respect‭ ‬in‭ ‬your‭ ‬speech‭ ‬and‭ ‬actions.
-  * Attempt‭ ‬collaboration‭ ‬before‭ ‬conflict.
-  * Refrain‭ ‬from‭ ‬demeaning,‭ ‬discriminatory,‭ ‬or‭ ‬harassing‭ ‬behavior‭ ‬and‭ ‬speech.
-  * Be‭ ‬mindful‭ ‬of‭ ‬your‭ ‬surroundings‭ ‬and‭ ‬of‭ ‬your‭ ‬fellow‭ ‬participants.‭ ‬Alert‭ ‬community‭ ‬leaders‭ ‬if‭ ‬you‭ ‬notice‭ ‬a‭ ‬dangerous‭ ‬situation,‭ ‬someone‭ ‬in‭ ‬distress,‭ ‬or‭ ‬violations‭ ‬of‭ ‬this‭ ‬Code‭ ‬of‭ ‬Conduct,‭ ‬even‭ ‬if‭ ‬they‭ ‬seem‭ ‬inconsequential.
+  * Participate in an authentic and active way. In doing so, you contribute to the health and longevity of this community.
+  * Exercise consideration and respect in your speech and actions.
+  * Attempt collaboration before conflict.
+  * Refrain from demeaning, discriminatory, or harassing behavior and speech.
+  * Be mindful of your surroundings and of your fellow participants. Alert community leaders if you notice a dangerous situation, someone in distress, or violations of this Code of Conduct, even if they seem inconsequential.
 
-## 4.‎ ‏Unacceptable‭ ‬Behavior
+## 4.‎ ‏Unacceptable Behavior
 
-Unacceptable‭ ‬behaviors‭ ‬include:‭ ‬intimidating,‭ ‬harassing,‭ ‬abusive,‭
-‬discriminatory,‭ ‬derogatory‭ ‬or‭ ‬demeaning‭ ‬speech‭ ‬or‭ ‬actions‭ ‬by‭
-‬any‭ ‬participant‭ ‬in‭ ‬our‭ ‬community‭ ‬online,‭ ‬at‭ ‬all‭ ‬related‭
-‬events‭ ‬and‭ ‬in‭ ‬one-on-one‭ ‬communications‭ ‬carried‭ ‬out‭ ‬in‭ ‬the‭
-‬context‭ ‬of‭ ‬community‭ ‬business.‭ ‬Community‭ ‬event‭ ‬venues‭ ‬may‭ ‬be‭
-‬shared‭ ‬with‭ ‬members‭ ‬of‭ ‬the‭ ‬public‭; ‬please‭ ‬be‭ ‬respectful‭ ‬to‭
-‬all‭ ‬patrons‭ ‬of‭ ‬these‭ ‬locations.
+Unacceptable behaviors include: intimidating, harassing, abusive,
+discriminatory, derogatory or demeaning speech or actions by
+any participant in our community online, at all related
+events and in one-on-one communications carried out in the
+context of community business. Community event venues may be
+shared with members of the public; please be respectful to
+all patrons of these locations.
 
-Harassment‭ ‬includes:‭ ‬harmful‭ ‬or‭ ‬prejudicial‭ ‬verbal‭ ‬or‭ ‬written‭
-‬comments‭ ‬related‭ ‬to‭ ‬gender,‭ ‬sexual‭ ‬orientation,‭ ‬race,‭
-‬religion,‭ ‬disability‭; ‬inappropriate‭ ‬use‭ ‬of‭ ‬nudity‭ ‬and/or‭
-‬sexual‭ ‬images‭ ‬in‭ ‬public‭ ‬spaces‭ (‬including‭ ‬presentation‭
-‬slides‭); ‬deliberate‭ ‬intimidation,‭ ‬stalking‭ ‬or‭ ‬following‭;
-‬harassing‭ ‬photography‭ ‬or‭ ‬recording‭; ‬sustained‭ ‬disruption‭ ‬of‭
-‬talks‭ ‬or‭ ‬other‭ ‬events‭; ‬inappropriate‭ ‬physical‭ ‬contact,‭ ‬and‭
-‬unwelcome‭ ‬sexual‭ ‬attention.
+Harassment includes: harmful or prejudicial verbal or written
+comments related to gender, sexual orientation, race,
+religion, disability; inappropriate use of nudity and/or
+sexual images in public spaces (including presentation
+slides); deliberate intimidation, stalking or following;
+harassing photography or recording; sustained disruption of
+talks or other events; inappropriate physical contact, and
+unwelcome sexual attention.
 
-## 5.‎ ‏Consequences‭ ‬of‭ ‬Unacceptable‭ ‬Behavior
+## 5.‎ ‏Consequences of Unacceptable Behavior
 
-Unacceptable‭ ‬behavior‭ ‬from‭ ‬any‭ ‬community‭ ‬member,‭ ‬including‭
-‬sponsors‭ ‬and‭ ‬those‭ ‬with‭ ‬decision-making‭ ‬authority,‭ ‬will‭ ‬not‭
-‬be‭ ‬tolerated.
+Unacceptable behavior from any community member, including
+sponsors and those with decision-making authority, will not
+be tolerated.
 
-Anyone‭ ‬asked‭ ‬to‭ ‬stop‭ ‬unacceptable‭ ‬behavior‭ ‬is‭ ‬expected‭ ‬to‭
-‬comply‭ ‬immediately.
+Anyone asked to stop unacceptable behavior is expected to
+comply immediately.
 
-If‭ ‬a‭ ‬community‭ ‬member‭ ‬engages‭ ‬in‭ ‬unacceptable‭ ‬behavior,‭ ‬the‭
-‬community‭ ‬organizers‭ ‬may‭ ‬take‭ ‬any‭ ‬action‭ ‬they‭ ‬deem‭
-‬appropriate,‭ ‬up‭ ‬to‭ ‬and‭ ‬including‭ ‬a‭ ‬temporary‭ ‬ban‭ ‬or‭
-‬permanent‭ ‬expulsion‭ ‬from‭ ‬the‭ ‬community‭ ‬without‭ ‬warning‭ (‬and‭
-‬without‭ ‬refund‭ ‬in‭ ‬the‭ ‬case‭ ‬of‭ ‬a‭ ‬paid‭ ‬event‭)‬.
+If a community member engages in unacceptable behavior, the
+community organizers may take any action they deem
+appropriate, up to and including a temporary ban or
+permanent expulsion from the community without warning (and
+without refund in the case of a paid event).
 
-## 6.‎ ‏If‭ ‬You‭ ‬Witness‭ ‬or‭ ‬Are‭ ‬Subject‭ ‬to‭ ‬Unacceptable‭ ‬Behavior
+## 6.‎ ‏If You Witness or Are Subject to Unacceptable Behavior
 
-If‭ ‬you‭ ‬are‭ ‬subject‭ ‬to‭ ‬or‭ ‬witness‭ ‬unacceptable‭ ‬behavior,‭ ‬or‭
-‬have‭ ‬any‭ ‬other‭ ‬concerns,‭ ‬please‭ ‬notify‭ ‬a‭ ‬community‭ ‬organizer‭
-‬as‭ ‬soon‭ ‬as‭ ‬possible.‭ [‬CONTACT‭_‬INFO‭_‬HERE‭]
+If you are subject to or witness unacceptable behavior, or
+have any other concerns, please notify a community organizer
+as soon as possible. [CONTACT_INFO_HERE]
 
-Additionally,‭ ‬community‭ ‬organizers‭ ‬are‭ ‬available‭ ‬to‭ ‬help‭
-‬community‭ ‬members‭ ‬engage‭ ‬with‭ ‬local‭ ‬law‭ ‬enforcement‭ ‬or‭ ‬to‭
-‬otherwise‭ ‬help‭ ‬those‭ ‬experiencing‭ ‬unacceptable‭ ‬behavior‭ ‬feel‭
-‬safe.‭ ‬In‭ ‬the‭ ‬context‭ ‬of‭ ‬in-person‭ ‬events,‭ ‬organizers‭ ‬will‭
-‬also‭ ‬provide‭ ‬escorts‭ ‬as‭ ‬desired‭ ‬by‭ ‬the‭ ‬person‭ ‬experiencing‭
-‬distress.
+Additionally, community organizers are available to help
+community members engage with local law enforcement or to
+otherwise help those experiencing unacceptable behavior feel
+safe. In the context of in-person events, organizers will
+also provide escorts as desired by the person experiencing
+distress.
 
-## 7.‎ ‏Addressing‭ ‬Grievances
+## 7.‎ ‏Addressing Grievances
 
-If‭ ‬you‭ ‬feel‭ ‬you‭ ‬have‭ ‬been‭ ‬falsely‭ ‬or‭ ‬unfairly‭ ‬accused‭ ‬of‭
-‬violating‭ ‬this‭ ‬Code‭ ‬of‭ ‬Conduct,‭ ‬you‭ ‬should‭ ‬notify‭
-‬GOVERNING‭_‬BODY‭ ‬with‭ ‬a‭ ‬concise‭ ‬description‭ ‬of‭ ‬your‭ ‬grievance.‭
-‬Your‭ ‬grievance‭ ‬will‭ ‬be‭ ‬handled‭ ‬in‭ ‬accordance‭ ‬with‭ ‬our‭
-‬existing‭ ‬governing‭ ‬policies.‭ [‬LINK‭_‬TO‭_‬POLICY‭]
+If you feel you have been falsely or unfairly accused of
+violating this Code of Conduct, you should notify
+GOVERNING_BODY with a concise description of your grievance.
+Your grievance will be handled in accordance with our
+existing governing policies. [LINK_TO_POLICY]
 
-[NOTE:‎ ‏Every‭ ‬organization‭'‬s‭ ‬governing‭ ‬policies‭ ‬should‭ ‬dictate‭
-‬how‭ ‬you‭ ‬handle‭ ‬warnings‭ ‬and‭ ‬expulsions‭ ‬of‭ ‬community‭ ‬members.‭
-‬It‭ ‬is‭ ‬strongly‭ ‬recommended‭ ‬that‭ ‬you‭ ‬mention‭ ‬those‭ ‬policies‭
-‬here‭ ‬or‭ ‬in‭ ‬Section‭ ‬7‭ ‬and‭ ‬that‭ ‬you‭ ‬include‭ ‬a‭ ‬mechanism‭
-‬for‭ ‬addressing‭ ‬grievances.‭]
+[NOTE:‎ ‏Every organization's governing policies should dictate
+how you handle warnings and expulsions of community members.
+It is strongly recommended that you mention those policies
+here or in Section 7 and that you include a mechanism
+for addressing grievances.]
 
 ## 8.‎ ‏Scope
 
-We‭ ‬expect‭ ‬all‭ ‬community‭ ‬participants‭ (‬contributors,‭ ‬paid‭ ‬or‭
-‬otherwise‭; ‬sponsors‭; ‬and‭ ‬other‭ ‬guests‭) ‬to‭ ‬abide‭ ‬by‭ ‬this‭
-‬Code‭ ‬of‭ ‬Conduct‭ ‬in‭ ‬all‭ ‬community‭ ‬venues‭—‬online‭ ‬and‭ ‬in-
-person‭—‬as‭ ‬well‭ ‬as‭ ‬in‭ ‬all‭ ‬one-on-one‭ ‬communications‭ ‬pertaining‭
-‬to‭ ‬community‭ ‬business.
+We expect all community participants (contributors, paid or
+otherwise; sponsors; and other guests) to abide by this
+Code of Conduct in all community venues—online and in-
+person—as well as in all one-on-one communications pertaining
+to community business.
 
-## 9.‎ ‏Contact‭ ‬info
+## 9.‎ ‏Contact info
 
-‎[‏YOUR‭ ‬CONTACT‭ ‬INFO‭ ‬HERE‭ ‬--‭ ‬this‭ ‬should‭ ‬be‭ ‬a‭ ‬single‭
-‬person‭ ‬or‭ ‬a‭ ‬small‭ ‬team‭ ‬who‭ ‬can‭ ‬respond‭ ‬to‭ ‬issues‭
-‬directly‭]
+‎[‏YOUR CONTACT INFO HERE -- this should be a single
+person or a small team who can respond to issues
+directly]
 
-## 10.‎ ‏License‭ ‬and‭ ‬attribution
+## 10.‎ ‏License and attribution
 
-This‭ ‬Code‭ ‬of‭ ‬Conduct‭ ‬is‭ ‬distributed‭ ‬under‭ ‬a‭ ‬[Creative‭
-‬Commons‭ ‬Attribution-ShareAlike‭ ‬license](http://creativecommons.org/licenses/by-sa/3.0/)
+This Code of Conduct is distributed under a [Creative
+Commons Attribution-ShareAlike license](http://creativecommons.org/licenses/by-sa/3.0/)
 
 _Revision 2.0, adopted by the [Stumptown
 Syndicate](http://stumptownsyndicate.org) board on 10 January 2013. Posted 17 March 2013._


### PR DESCRIPTION
I removed a bunch of invisible characters that were making the policy awkward to edit in Emacs. Please let me know if they served a purpose, so I can restore them in my own branch. Thanks so much for sharing this policy framework :+1: 
