### PR TITLE
typo "derived"

### DIFF
--- a/syndicate_code_of_conduct.md
+++ b/syndicate_code_of_conduct.md
@@ -79,7 +79,7 @@ This code of conduct and its related procedures also applies to unacceptable beh
 
 The Citizen Code of Conduct is distributed by [Stumptown Syndicate](http://stumptownsyndicate.org) under a [Creative Commons Attribution-ShareAlike license](http://creativecommons.org/licenses/by-sa/3.0/). 
 
-Portions of text dervied from the [Django Code of Conduct](https://www.djangoproject.com/conduct/ and the [Geek Feminism Anti-Harassment Policy](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy).
+Portions of text derived from the [Django Code of Conduct](https://www.djangoproject.com/conduct/ and the [Geek Feminism Anti-Harassment Policy](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy).
 
 _Revision 2.2. Posted 4 February 2016._
 


### PR DESCRIPTION
same as https://github.com/stumpsyn/policies/commit/b96b4a7c4bb476f696663e27a66d0c8b4f9c1a62

Same typo is there:
http://citizencodeofconduct.org/